### PR TITLE
Remove CSS quotes when adding images

### DIFF
--- a/tasks/manifest-generator.js
+++ b/tasks/manifest-generator.js
@@ -232,6 +232,7 @@ module.exports = function(grunt) {
                 if (/^['"]?data:/i.test(str)) {
                   return;
                 }
+                str = str.replace(/["']/g, "");
                 __path = Util.getRelativePath(manifestfile, Util.getAbsolutePath(_path, str));
                 imageList.push(__path);
               });

--- a/tasks/manifest-generator.js
+++ b/tasks/manifest-generator.js
@@ -30,7 +30,9 @@ module.exports = function(grunt) {
       includeJS: true,
       excludeFiles: [],
       extraFiles:[],
-      network: '*'
+      network: '*',
+      fallback: '',
+      settings: []
     });
     //保留任务完成句柄
     var Alldone = this.async();
@@ -68,11 +70,17 @@ module.exports = function(grunt) {
       options = options || {};
       _text.push('CACHE MANIFEST');
       _text.push('# ' + new Date());
-      _text.push('NETWORK:');
-      _text.push(options.network || '*');
       _text.push('CACHE:');
       for (p in files) {
         _text.push(p);
+      }
+      _text.push('NETWORK:');
+      _text.push(options.network || '*');
+      _text.push('FALLBACK:');
+      _text.push(options.fallback || '');
+      _text.push('SETTINGS:');
+      for (var i = 0 ; i < options.settings.length ; i++) {
+        _text.push(options.settings[i]);
       }
       File.write(path, _text.join('\n'));
     }


### PR DESCRIPTION
There is a bug with CSS such as:
`url("foo.png")` or `url('foo.png')` where it would be rendered in the manifest file as

```
"foo.png"
'foo.png'
```

This commit fixes that by replacing quotes in this area with empty string.
